### PR TITLE
add participant update description

### DIFF
--- a/rmf_traffic_msgs/CMakeLists.txt
+++ b/rmf_traffic_msgs/CMakeLists.txt
@@ -61,6 +61,7 @@ set(msg_files
   "msg/ScheduleQueryParticipants.msg"
   "msg/ScheduleQuerySpacetime.msg"
   "msg/ScheduleRegister.msg"
+  "msg/ScheduleUpdateParticipant.msg"
   "msg/ScheduleWriterItem.msg"
   "msg/Shape.msg"
   "msg/ShapeContext.msg"

--- a/rmf_traffic_msgs/msg/SchedulePatch.msg
+++ b/rmf_traffic_msgs/msg/SchedulePatch.msg
@@ -3,6 +3,9 @@ uint64[] unregister_participants
 
 ScheduleRegister[] register_participants
 
+# Changes in the participants footprint and description
+ScheduleUpdateParticipant[] updated_footprints
+
 # The changes to the schedule, grouped into the different participants
 ScheduleParticipantPatch[] participants
 

--- a/rmf_traffic_msgs/msg/ScheduleUpdateParticipant.msg
+++ b/rmf_traffic_msgs/msg/ScheduleUpdateParticipant.msg
@@ -1,0 +1,4 @@
+
+uint64 participant_id
+
+ParticipantDescription description


### PR DESCRIPTION
## New feature implementation

### Implemented feature

This adds an update feature to the database. We need this in order to allow for participant descriptions to change if the fleetadapter requests such a change.

This feature is related to the following PRs:

1. [rmf_trasffic](https://github.com/open-rmf/rmf_traffic/pull/2)
2. [rmf_ros2](https://github.com/open-rmf/rmf_ros2/pull/2)
3. [rmf_internal_msgs](https://github.com/open-rmf/rmf_internal_msgs/pull/2)

### Implementation description

##### Changes in `rmf_traffic`
There isn't too much magic going on. This PR adds a `update_descriptions` function to the writer API through which a client can update the footprint of an already registered client. To maintain sync with the mirrors we add an  `UpdateParticipantInfo` class to the `Change` class and a ` updated()` field to the patches class. This allows the database to update its mirrors accordingly.

At the heart of the change is a hash table `UpdateParticipantDescription update_participant_version;`  indexed by participant ID. If a participant is updated its ID is set in the hashtable along with the version in which an update is performed. During synchronization, the mirrors use this hash table for this job.

##### Changes in `rmf_traffic_ros2`
First of all, `ParticipantRegistry::add_or_register_participant` now also handles updates. This is done by keeping track of footprints within the `ParticipantRegistryClass` to detect an y changes. The other major change is that in order to reduce the log file size, instead of being an append-only log `YamlLogger` overwrites the entire `.rmf_schedule_node.yaml`. This is fine as we do not expect too many participants. 

##### Changes in `ros_internal_msgs`
We add a message to handle updates.

#### Testing with `rmf_ros2`
![footprint_update](https://user-images.githubusercontent.com/542272/110572787-18bbc080-8195-11eb-9f47-2f2fd37fd212.gif)

In the above gif you can see the footprint change to reproduce, you can checkout the `temporary/test_restart_fleet_adapter` branch in [rmf_demos](https://github.com/open-rmf/rmf_demos/tree/temporary/test_restart_fleet_adapter)

In one terminal window run `ros2 launch rmf_demos office.launch.xml` and in another run `ros2 launch rmf_demos adapters.launch`. Then edit the parameters in `tinyRobot_adapter.launch` and restart `adapters.launch` if successful,
you will see a change in the footprint.
