### PR TITLE
Lane closure messages

### DIFF
--- a/rmf_fleet_msgs/CHANGELOG.rst
+++ b/rmf_fleet_msgs/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog for package rmf_fleet_msgs
 
 1.3.0 (2021-XX-XX)
 ------------------
+* Added messages for opening/closing lanes: [#5](https://github.com/open-rmf/rmf_internal_msgs/pull/5)
 * Added Docking related messages: [#217](https://github.com/osrf/rmf_core/pull/217)
 
 1.2.0 (2021-01-05)

--- a/rmf_fleet_msgs/CMakeLists.txt
+++ b/rmf_fleet_msgs/CMakeLists.txt
@@ -29,6 +29,7 @@ set(msg_files
   "msg/DockParameter.msg"
   "msg/Dock.msg"
   "msg/DockSummary.msg"
+  "msg/LaneRequest.msg"
 )
 
 set(srv_files

--- a/rmf_fleet_msgs/CMakeLists.txt
+++ b/rmf_fleet_msgs/CMakeLists.txt
@@ -30,6 +30,7 @@ set(msg_files
   "msg/Dock.msg"
   "msg/DockSummary.msg"
   "msg/LaneRequest.msg"
+  "msg/ClosedLanes.msg"
 )
 
 set(srv_files

--- a/rmf_fleet_msgs/msg/ClosedLanes.msg
+++ b/rmf_fleet_msgs/msg/ClosedLanes.msg
@@ -1,0 +1,3 @@
+
+string fleet_name
+uint64[] closed_lanes

--- a/rmf_fleet_msgs/msg/LaneRequest.msg
+++ b/rmf_fleet_msgs/msg/LaneRequest.msg
@@ -1,0 +1,3 @@
+
+uint64[] open_lanes
+uint64[] close_lanes

--- a/rmf_fleet_msgs/msg/LaneRequest.msg
+++ b/rmf_fleet_msgs/msg/LaneRequest.msg
@@ -1,3 +1,4 @@
 
+string fleet_name
 uint64[] open_lanes
 uint64[] close_lanes


### PR DESCRIPTION
## New feature implementation

### Implemented feature

Add messages for requesting lanes to open or close and for reporting which lanes are currently closed.