### PR TITLE
revive task msg

### DIFF
--- a/rmf_task_msgs/CMakeLists.txt
+++ b/rmf_task_msgs/CMakeLists.txt
@@ -40,6 +40,7 @@ set(msg_files
 set(srv_files
   "srv/SubmitTask.srv"
   "srv/CancelTask.srv"
+  "srv/ReviveTask.srv"
   "srv/GetTaskList.srv"
 )
 

--- a/rmf_task_msgs/srv/ReviveTask.srv
+++ b/rmf_task_msgs/srv/ReviveTask.srv
@@ -1,0 +1,14 @@
+# Revive a previously cancelled or failed task. This will reinitiate
+# a bidding sequence to reassign this task.
+
+# Identifier for who is requesting the service
+string requester
+
+# task that was previously cancelled or failed
+string task_id
+
+---
+
+# Confirmation that this service call is processed
+bool success
+


### PR DESCRIPTION
This is the first step towards reviving a task that was previously cancelled or failed due to a certain error. https://github.com/open-rmf/rmf_ros2/issues/16.

The idea here is that, if a robot faces an error, it will report a failed state in `TaskSummary.msg`. The user will then have the option to revive any failed task (via an api from the `dispatcher.hpp` or the `ReviveTask.srv` call to the dispatcher). The dispatcher node will "revive" the task by reinitiating a bidding process to reassign the incompleted task. The same applies to a cancelled task.

Note that this "task revival" sequence will only be triggered by the user. @mxgrey, feedback is welcome!