### PR TITLE
edit task srv msgs

### DIFF
--- a/rmf_task_msgs/srv/CancelTask.srv
+++ b/rmf_task_msgs/srv/CancelTask.srv
@@ -10,3 +10,7 @@ string task_id
 
 # Confirmation that this service call is processed
 bool success
+
+# This will provide a verbose message regarding task cancellation
+string message
+

--- a/rmf_task_msgs/srv/SubmitTask.srv
+++ b/rmf_task_msgs/srv/SubmitTask.srv
@@ -6,12 +6,6 @@ string requester
 # desciption of task
 TaskDescription description
 
-# fleet selection evaluator
-uint8 evaluator
-uint8 LOWEST_DIFF_COST_EVAL=0
-uint8 LOWEST_COST_EVAL=1
-uint8 QUICKEST_FINISH_EVAL=2
-
 ---
 
 # Confirmation that this service call is processed
@@ -19,3 +13,7 @@ bool success
 
 # generated task ID by dispatcher node
 string task_id
+
+# This will provide a verbose message regarding task submission
+string message
+


### PR DESCRIPTION
## Fix

### Update Task Srv Msgs

This PR is to address: https://github.com/open-rmf/rmf_internal_msgs/issues/8 and https://github.com/open-rmf/rmf_internal_msgs/issues/4. A `message` field is added to both `Submit` and `Cancel` service call, this will provide more info when during a failed request.
