### PR TITLE
Add redundancy to the traffic schedule node: Add necessary messages

### DIFF
--- a/rmf_traffic_msgs/CMakeLists.txt
+++ b/rmf_traffic_msgs/CMakeLists.txt
@@ -29,6 +29,8 @@ set(msg_files
   "msg/Circle.msg"
   "msg/ConvexShape.msg"
   "msg/ConvexShapeContext.msg"
+  "msg/FailOverEvent.msg"
+  "msg/Heartbeat.msg"
   "msg/Itinerary.msg"
   "msg/ItineraryClear.msg"
   "msg/ItineraryDelay.msg"
@@ -77,6 +79,7 @@ set(srv_files
   "srv/UnregisterQuery.srv"
   "srv/RegisterParticipant.srv"
   "srv/UnregisterParticipant.srv"
+  "srv/TestReconnect.srv"
 )
 
 rosidl_generate_interfaces(${PROJECT_NAME}

--- a/rmf_traffic_msgs/CMakeLists.txt
+++ b/rmf_traffic_msgs/CMakeLists.txt
@@ -63,6 +63,7 @@ set(msg_files
   "msg/ScheduleParticipantPatch.msg"
   "msg/SchedulePatch.msg"
   "msg/ScheduleQuery.msg"
+  "msg/ScheduleQueries.msg"
   "msg/ScheduleQueryParticipants.msg"
   "msg/ScheduleQuerySpacetime.msg"
   "msg/ScheduleWriterItem.msg"

--- a/rmf_traffic_msgs/CMakeLists.txt
+++ b/rmf_traffic_msgs/CMakeLists.txt
@@ -80,7 +80,6 @@ set(srv_files
   "srv/UnregisterQuery.srv"
   "srv/RegisterParticipant.srv"
   "srv/UnregisterParticipant.srv"
-  "srv/TestReconnect.srv"
 )
 
 rosidl_generate_interfaces(${PROJECT_NAME}

--- a/rmf_traffic_msgs/CMakeLists.txt
+++ b/rmf_traffic_msgs/CMakeLists.txt
@@ -41,7 +41,6 @@ set(msg_files
   "msg/ParticipantDescription.msg"
   "msg/Profile.msg"
   "msg/Region.msg"
-  "msg/RequestChanges.msg"
   "msg/Route.msg"
   "msg/ScheduleChangeAdd.msg"
   "msg/ScheduleChangeCull.msg"
@@ -78,6 +77,7 @@ set(msg_files
 set(srv_files
   "srv/RegisterQuery.srv"
   "srv/UnregisterQuery.srv"
+  "srv/RequestChanges.srv"
   "srv/RegisterParticipant.srv"
   "srv/UnregisterParticipant.srv"
 )

--- a/rmf_traffic_msgs/msg/MirrorUpdate.msg
+++ b/rmf_traffic_msgs/msg/MirrorUpdate.msg
@@ -1,6 +1,9 @@
 # The ID of the query description this update is for
 uint64 query_id
 
+# The query itself
+ScheduleQuery query
+
 # The version of the database this update provides
 uint64 database_version
 

--- a/rmf_traffic_msgs/msg/RequestChanges.msg
+++ b/rmf_traffic_msgs/msg/RequestChanges.msg
@@ -1,8 +1,0 @@
-# Query ID to request a full participants list for
-uint64 query_id
-
-# Version to request changes from; ignored if full_update is true
-uint64 version
-
-# Request a full update rather than from a specific version
-bool full_update false

--- a/rmf_traffic_msgs/msg/ScheduleQueries.msg
+++ b/rmf_traffic_msgs/msg/ScheduleQueries.msg
@@ -1,0 +1,6 @@
+# The list of known queries
+ScheduleQuery[] queries
+# The list of IDs for those queries
+uint64[] ids
+# The subscriber counts for those queries
+uint64[] subscriber_counts

--- a/rmf_traffic_msgs/srv/RequestChanges.srv
+++ b/rmf_traffic_msgs/srv/RequestChanges.srv
@@ -1,0 +1,15 @@
+# Query ID to request a full participants list for
+uint64 query_id
+
+# Version to request changes from; ignored if full_update is true
+uint64 version
+
+# Request a full update rather than from a specific version
+bool full_update false
+
+---
+
+# Response to the request
+uint8 REQUEST_ACCEPTED=1
+uint8 UNKNOWN_QUERY_ID=2
+uint8 result

--- a/rmf_traffic_msgs/srv/TestReconnect.srv
+++ b/rmf_traffic_msgs/srv/TestReconnect.srv
@@ -1,0 +1,3 @@
+int32 value
+---
+int32 doubled

--- a/rmf_traffic_msgs/srv/TestReconnect.srv
+++ b/rmf_traffic_msgs/srv/TestReconnect.srv
@@ -1,3 +1,0 @@
-int32 value
----
-int32 doubled


### PR DESCRIPTION
## New feature implementation

### Implemented feature

This PR adds new messages required to support redundancy in the traffic schedule node (see [open-rmf/rmf_ros2!61](https://github.com/open-rmf/rmf_ros2/pull/61) for the main part of the implementation).

Resolves open-rmf/rmf#57.

### Implementation description

The messages are:

- a heartbeat (empty; the presence of the topic is sufficient),
- a fail over event notification to notify anyone interested that the backup node has been activated upon detecting the death of the primary node (empty), and
- a message that can hold all the currently-registered queries and their IDs and subscriber counts, for use in kick-starting the backup schedule node.