### PR TITLE
Add enum for completed charging.

### DIFF
--- a/rmf_charger_msgs/msg/ChargerState.msg
+++ b/rmf_charger_msgs/msg/ChargerState.msg
@@ -4,6 +4,7 @@ builtin_interfaces/Time charger_time
 uint32 CHARGER_IDLE = 1      # Charger is not occupied
 uint32 CHARGER_ASSIGNED = 2  # Charger has been assigned a robot
 uint32 CHARGER_CHARGING = 3  # Charger is charging
+uint32 CHARGER_COMPLETED = 4 # Charging is completed
 uint32 CHARGER_ERROR = 200   # Error state, see error_message for info
 
 uint32 state  # One of the previously enumerated states


### PR DESCRIPTION
This PR contains a new enum for when charging has been completed. 

Signed-off-by: Arjo Chakravarty <arjo@openrobotics.org>