### PR TITLE
Add a field to indicate when an update is a remediation

### DIFF
--- a/rmf_traffic_msgs/msg/MirrorUpdate.msg
+++ b/rmf_traffic_msgs/msg/MirrorUpdate.msg
@@ -6,3 +6,7 @@ uint64 database_version
 
 # The patch for the query
 SchedulePatch patch
+
+# True if this update is meant to remedy a mirror that has fallen
+# out of sync
+bool is_remedial_update


### PR DESCRIPTION
This new field helps mirrors know when it's okay to ignore an incoming update.