### PR TITLE
Feature/task-msgs

### DIFF
--- a/rmf_task_msgs/msg/Clean.msg
+++ b/rmf_task_msgs/msg/Clean.msg
@@ -1,3 +1,8 @@
+# task_id is intended to be a pseudo-random string generated
+# by the caller which can be used to identify this task as it
+# moves between the queues to completion (or failure).
+string task_id
+
 # robot_type can be used to specify a particular robot fleet
 # for this request
 string robot_type

--- a/rmf_task_msgs/msg/Clean.msg
+++ b/rmf_task_msgs/msg/Clean.msg
@@ -1,3 +1,7 @@
+# robot_type can be used to specify a particular robot fleet
+# for this request
+string robot_type
+
 # The name of the waypoint where the robot should begin its pre-configured
 # cleaning job. 
 string start_waypoint

--- a/rmf_task_msgs/msg/Delivery.msg
+++ b/rmf_task_msgs/msg/Delivery.msg
@@ -3,6 +3,10 @@
 # moves between the queues to completion (or failure).
 string task_id
 
+# robot_type can be used to specify a particular robot fleet
+# for this request
+string robot_type
+
 rmf_dispenser_msgs/DispenserRequestItem[] items
 
 string pickup_place_name


### PR DESCRIPTION
## Make task-msgs more consistent
Currently, there are a few task types: station, loop, delivery, clean.  The station and loop task messages have a `robot_type` field.  As documented in the comments, this field can be used to specify a particular robot fleet for the requests.  The delivery and clean task messages do not seem to have that field.  I've made the change to include that field for both the delivery and clean task messages.

Also, I think it'd be more consistent if the clean task message has a task_id field.

I'm not sure whether you want the tow task message to include the `robot_type` field.  I can include that as well if you want.  Next, do you want to include `TYPE_TOW=6` in `TaskType.msg`?

Thanks.