### PR TITLE
SiteMap message that is just a blob and encoding flag

### DIFF
--- a/rmf_site_map_msgs/CMakeLists.txt
+++ b/rmf_site_map_msgs/CMakeLists.txt
@@ -1,0 +1,31 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(rmf_site_map_msgs)
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  # we dont use add_compile_options with pedantic in message packages
+  # because the Python C extensions dont comply with it
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic")
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(builtin_interfaces REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+
+set(msg_files
+  "msg/SiteMap.msg"
+)
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  ${msg_files}
+  DEPENDENCIES builtin_interfaces
+  ADD_LINTER_TESTS
+)
+
+ament_export_dependencies(rosidl_default_runtime)
+
+ament_package()

--- a/rmf_site_map_msgs/msg/SiteMap.msg
+++ b/rmf_site_map_msgs/msg/SiteMap.msg
@@ -1,0 +1,5 @@
+uint32 MAP_DATA_UNDEFINED=0
+uint32 MAP_DATA_GPKG_GZ=1
+
+uint32 encoding
+uint8[] data

--- a/rmf_site_map_msgs/msg/SiteMap.msg
+++ b/rmf_site_map_msgs/msg/SiteMap.msg
@@ -1,5 +1,6 @@
 uint32 MAP_DATA_UNDEFINED=0
-uint32 MAP_DATA_GPKG_GZ=1
+uint32 MAP_DATA_GPKG=1
+uint32 MAP_DATA_GPKG_GZ=2
 
 uint32 encoding
 uint8[] data

--- a/rmf_site_map_msgs/package.xml
+++ b/rmf_site_map_msgs/package.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>rmf_site_map_msgs</name>
+  <version>0.0.1</version>
+  <description>Messages that contain GeoPackage maps</description>
+  <maintainer email="morgan@openrobotics.org">Morgan Quigley</maintainer>
+  <maintainer email="marco@openrobotics.org">Marco A. Gutiérrez</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
+
+  <build_depend>builtin_interfaces</build_depend>
+
+  <exec_depend>builtin_interfaces</exec_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
+
+  <test_depend>ament_lint_common</test_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>
+


### PR DESCRIPTION
The idea of this SiteMap message is to include everything that `BuildingMap` has, but using the GeoPackage format to enable the use of other open-source tools like QGIS, better scaling properties, and so on. Because GeoPackage (SQLite3) includes some database storage overhead, it's helpful to `gzip` it to save network bandwidth.

Signed-off-by: Morgan Quigley <morgan@osrfoundation.org>