### PR TITLE
Add approach_speed field to Location message

### DIFF
--- a/rmf_fleet_msgs/msg/Location.msg
+++ b/rmf_fleet_msgs/msg/Location.msg
@@ -3,8 +3,9 @@ float32 x
 float32 y
 float32 yaw
 
-# Target speed of the lane leading to this waypoint, to be respected if > 0.0
-float32 approach_speed
+bool obey_approach_speed_limit false
+# Speed limit of the lane leading to this waypoint
+float32 approach_speed_limit
 
 string level_name
 uint64 index

--- a/rmf_fleet_msgs/msg/Location.msg
+++ b/rmf_fleet_msgs/msg/Location.msg
@@ -2,6 +2,9 @@ builtin_interfaces/Time t
 float32 x
 float32 y
 float32 yaw
-float32 approach_speed # Target speed of the lane leading to this waypoint
+
+# Target speed of the lane leading to this waypoint, to be respected if > 0.0
+float32 approach_speed
+
 string level_name
 uint64 index

--- a/rmf_fleet_msgs/msg/Location.msg
+++ b/rmf_fleet_msgs/msg/Location.msg
@@ -2,5 +2,6 @@ builtin_interfaces/Time t
 float32 x
 float32 y
 float32 yaw
+float32 approach_speed # Target speed of the lane leading to this waypoint
 string level_name
 uint64 index

--- a/rmf_fleet_msgs/msg/Location.msg
+++ b/rmf_fleet_msgs/msg/Location.msg
@@ -4,7 +4,7 @@ float32 y
 float32 yaw
 
 bool obey_approach_speed_limit false
-# Speed limit of the lane leading to this waypoint
+# Speed limit of the lane leading to this waypoint in m/s
 float32 approach_speed_limit
 
 string level_name


### PR DESCRIPTION
## New feature implementation

### Implemented feature

This PR allows simulated robots to respect speed limits. Speed limits for lanes are kept track of by upstream nodes (i.e. fleet adapters / managers) and published in the robot_path_requests message through a new field `approach_speed`. For each location `approach_speed` denotes the speed limit of the lane leading to it.