### PR TITLE
Add an error field for RequestChanges

### DIFF
--- a/rmf_traffic_msgs/srv/RequestChanges.srv
+++ b/rmf_traffic_msgs/srv/RequestChanges.srv
@@ -12,4 +12,6 @@ bool full_update false
 # Response to the request
 uint8 REQUEST_ACCEPTED=1
 uint8 UNKNOWN_QUERY_ID=2
+uint8 ERROR=3
 uint8 result
+string error


### PR DESCRIPTION
It's possible for malformed requests to come in, so we will respond to those with an error label and a string to describe the error.