### PR TITLE
Add LaneStates msg

### DIFF
--- a/rmf_fleet_msgs/CMakeLists.txt
+++ b/rmf_fleet_msgs/CMakeLists.txt
@@ -32,6 +32,8 @@ set(msg_files
   "msg/LaneRequest.msg"
   "msg/ClosedLanes.msg"
   "msg/InterruptRequest.msg"
+  "msg/SpeedLimitedLane.msg"
+  "msg/LaneStates.msg"
 )
 
 set(srv_files

--- a/rmf_fleet_msgs/msg/LaneStates.msg
+++ b/rmf_fleet_msgs/msg/LaneStates.msg
@@ -1,0 +1,7 @@
+string fleet_name
+
+# The indices of the lanes that are currently closed
+uint64[] closed_lanes
+
+# Lanes that have speed limits
+SpeedLimitedLane[] speed_limits

--- a/rmf_fleet_msgs/msg/LaneStates.msg
+++ b/rmf_fleet_msgs/msg/LaneStates.msg
@@ -1,3 +1,4 @@
+# The name of the fleet with closed or speed limited lanes
 string fleet_name
 
 # The indices of the lanes that are currently closed

--- a/rmf_fleet_msgs/msg/SpeedLimitedLane.msg
+++ b/rmf_fleet_msgs/msg/SpeedLimitedLane.msg
@@ -1,0 +1,2 @@
+uint64 lane_index
+float64 speed_limit

--- a/rmf_fleet_msgs/msg/SpeedLimitedLane.msg
+++ b/rmf_fleet_msgs/msg/SpeedLimitedLane.msg
@@ -1,2 +1,5 @@
+# The index of the lane with a speed limit
 uint64 lane_index
+
+# The imposed speed limit for the lane
 float64 speed_limit


### PR DESCRIPTION
This PR adds `LaneStates.msg` to `rmf_fleet_msgs`. The purpose of this message is to bundle lanes that are closed and those that have speed limits imposed. 

Initially wanted to just include `ClosedLanes.msg` inside `LaneStates.msg` but decided against it due to duplicate `fleet_name` fields. Open to feedback!

Signed-off-by: Yadunund <yadunund@gmail.com>
