### PR TITLE
Replace BoundingBox msgs from vision_msgs with internal variants

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -48,7 +48,7 @@ jobs:
           colcon-defaults: |
             {
               "build": {
-                "mixin": ["coverage-gcc", lld]
+                "mixin": ["coverage-gcc", "lld"]
               }
             }
           colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,6 +4,8 @@ jobs:
   build_and_test:
     name: Build and test
     runs-on: ubuntu-20.04
+    container:
+      image: rostooling/setup-ros-docker:ubuntu-focal-latest
     strategy:
       matrix:
         ros_distribution:
@@ -11,11 +13,16 @@ jobs:
           - galactic
     steps:
       - name: deps
-        uses: ros-tooling/setup-ros@v0.2
+        uses: ros-tooling/setup-ros@v0.3
         with:
           required-ros-distributions: ${{ matrix.ros_distribution }}
+      - name: install_clang
+        run: sudo apt update && sudo apt install -y clang clang-tools lld
       - name: build
         uses: ros-tooling/action-ros-ci@v0.2
+        env:
+          CC: clang
+          CXX: clang++
         with:
           target-ros2-distro: ${{ matrix.ros_distribution }}
           # Build all packages listed in the meta package, as well as their
@@ -27,6 +34,9 @@ jobs:
             rmf_fleet_msgs
             rmf_ingestor_msgs
             rmf_lift_msgs
+            rmf_obstacle_msgs
+            rmf_scheduler_msgs
+            rmf_site_map_msgs
             rmf_task_msgs
             rmf_traffic_msgs
             rmf_workcell_msgs
@@ -38,7 +48,7 @@ jobs:
           colcon-defaults: |
             {
               "build": {
-                "mixin": ["coverage-gcc"]
+                "mixin": ["coverage-gcc", lld]
               }
             }
           colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
@@ -48,4 +58,3 @@ jobs:
           files: ros_ws/lcov/total_coverage.info
           flags: tests
           name: lean_and_mean_codecov_bot
-

--- a/rmf_obstacle_msgs/CMakeLists.txt
+++ b/rmf_obstacle_msgs/CMakeLists.txt
@@ -16,10 +16,11 @@ find_package(ament_cmake REQUIRED)
 find_package(builtin_interfaces REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
-find_package(vision_msgs REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 
 set(msg_files
+  "msg/BoundingBox2D.msg"
+  "msg/BoundingBox3D.msg"
   "msg/Obstacle.msg"
   "msg/Obstacles.msg"
 )
@@ -27,7 +28,7 @@ set(msg_files
 rosidl_generate_interfaces(${PROJECT_NAME}
   ${msg_files}
   ${srv_files}
-  DEPENDENCIES builtin_interfaces geometry_msgs vision_msgs std_msgs
+  DEPENDENCIES builtin_interfaces geometry_msgs std_msgs
   ADD_LINTER_TESTS
 )
 

--- a/rmf_obstacle_msgs/CMakeLists.txt
+++ b/rmf_obstacle_msgs/CMakeLists.txt
@@ -19,7 +19,6 @@ find_package(geometry_msgs REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 
 set(msg_files
-  "msg/BoundingBox2D.msg"
   "msg/BoundingBox3D.msg"
   "msg/Obstacle.msg"
   "msg/Obstacles.msg"

--- a/rmf_obstacle_msgs/CMakeLists.txt
+++ b/rmf_obstacle_msgs/CMakeLists.txt
@@ -13,10 +13,11 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake REQUIRED)
-find_package(builtin_interfaces REQUIRED)
-find_package(std_msgs REQUIRED)
-find_package(geometry_msgs REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
+
+find_package(builtin_interfaces REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(std_msgs REQUIRED)
 
 set(msg_files
   "msg/BoundingBox3D.msg"

--- a/rmf_obstacle_msgs/msg/BoundingBox2D.msg
+++ b/rmf_obstacle_msgs/msg/BoundingBox2D.msg
@@ -1,7 +1,0 @@
-# A 2D bounding box that can be rotated about its center.
-
-# The 2D position and orientation of the bounding box center.
-geometry_msgs/Pose2D center
-
-float64 size_x
-float64 size_y

--- a/rmf_obstacle_msgs/msg/BoundingBox2D.msg
+++ b/rmf_obstacle_msgs/msg/BoundingBox2D.msg
@@ -1,0 +1,7 @@
+# A 2D bounding box that can be rotated about its center.
+
+# The 2D position and orientation of the bounding box center.
+geometry_msgs/Pose2D center
+
+float64 size_x
+float64 size_y

--- a/rmf_obstacle_msgs/msg/BoundingBox3D.msg
+++ b/rmf_obstacle_msgs/msg/BoundingBox3D.msg
@@ -1,0 +1,7 @@
+# A 3D bounding box
+
+# The 3D position and orientation of the bounding box center
+geometry_msgs/Pose center
+
+# The total size of the bounding box, in meters, surrounding the object's center
+geometry_msgs/Vector3 size

--- a/rmf_obstacle_msgs/msg/Obstacle.msg
+++ b/rmf_obstacle_msgs/msg/Obstacle.msg
@@ -16,7 +16,7 @@ string level_name
 string classification
 
 # Bounding box of the obstacle
-vision_msgs/BoundingBox3D bbox
+BoundingBox3D bbox
 
 # 3D obstacle data that can be deserialized into an octree.
 # Resolution (in m) of the smallest octree node.

--- a/rmf_obstacle_msgs/package.xml
+++ b/rmf_obstacle_msgs/package.xml
@@ -10,12 +10,12 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <build_depend>builtin_interfaces</build_depend>
-  <build_depend>std_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
+  <build_depend>std_msgs</build_depend>
 
   <exec_depend>builtin_interfaces</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>
 

--- a/rmf_obstacle_msgs/package.xml
+++ b/rmf_obstacle_msgs/package.xml
@@ -12,12 +12,10 @@
   <build_depend>builtin_interfaces</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
-  <build_depend>vision_msgs</build_depend>
 
   <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
-  <exec_depend>vision_msgs</exec_depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>
 


### PR DESCRIPTION
Signed-off-by: Yadunund <yadunund@gmail.com>

The msg definitions for `vision_msgs::BoundingBox3D` and `vision_msgs::BoundingBox2D` have API breaking changes between `galactic` and `humble` versions. To continue supporting both ROS 2 versions in RMF, this PR updates the `Obstacle` msg definition to include an internal BoundingBox msg and not rely on `vision_msgs`. But the new messages have the same definition as the `galactic` version of `vision_msgs`.

See https://github.com/ros-perception/vision_msgs
