### PR TITLE
Add CleanTask messages

### DIFF
--- a/rmf_fleet_msgs/CMakeLists.txt
+++ b/rmf_fleet_msgs/CMakeLists.txt
@@ -35,6 +35,9 @@ set(msg_files
   "msg/SpeedLimitedLane.msg"
   "msg/SpeedLimitRequest.msg"
   "msg/LaneStates.msg"
+  "msg/CleanTaskSummary.msg"
+  "msg/CleanTask.msg"
+  "msg/CleanTaskParameter.msg"
 )
 
 set(srv_files

--- a/rmf_fleet_msgs/msg/CleanTask.msg
+++ b/rmf_fleet_msgs/msg/CleanTask.msg
@@ -1,0 +1,2 @@
+string fleet_name
+CleanTaskParameter[] params

--- a/rmf_fleet_msgs/msg/CleanTaskParameter.msg
+++ b/rmf_fleet_msgs/msg/CleanTaskParameter.msg
@@ -1,0 +1,4 @@
+# name of the cleaning task
+string name
+
+Location[] path

--- a/rmf_fleet_msgs/msg/CleanTaskSummary.msg
+++ b/rmf_fleet_msgs/msg/CleanTaskSummary.msg
@@ -1,0 +1,1 @@
+CleanTask[] clean_tasks


### PR DESCRIPTION
This PR adds `CleanTask` msgs to facilitate with publishing a summary of clean task names and corresponding coordinates to fleet managers and adapters.