### PR TITLE
Add rosidl_default_generators to rmf_obstacle dependencies

### DIFF
--- a/rmf_obstacle_msgs/package.xml
+++ b/rmf_obstacle_msgs/package.xml
@@ -9,6 +9,8 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
+
   <build_depend>builtin_interfaces</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>std_msgs</build_depend>


### PR DESCRIPTION
## Bug fix

### Fixed bug

Missing `buildtool_dependency` is causing released the `rmf_obstacle_msgs` package to fail building.
Specifically this message is observed in the buildfarm:

```
14:19:14 CMake Error at CMakeLists.txt:16 (find_package):
14:19:14   By not providing "Findrosidl_default_generators.cmake" in CMAKE_MODULE_PATH
14:19:14   this project has asked CMake to find a package configuration file provided
14:19:14   by "rosidl_default_generators", but CMake did not find one.
14:19:14 
14:19:14   Could not find a package configuration file provided by
14:19:14   "rosidl_default_generators" with any of the following names:
14:19:14 
14:19:14     rosidl_default_generatorsConfig.cmake
14:19:14     rosidl_default_generators-config.cmake
14:19:14 
14:19:14   Add the installation prefix of "rosidl_default_generators" to
14:19:14   CMAKE_PREFIX_PATH or set "rosidl_default_generators_DIR" to a directory
14:19:14   containing one of the above files.  If "rosidl_default_generators" provides
14:19:14   a separate development package or SDK, be sure it has been installed.
14:19:14 
14:19:14 
14:19:14 -- Configuring incomplete, errors occurred!
```

### Fix applied

Add the missing `buildtool_dependency`, in line with what is done with the rest of the packages