### PR TITLE
Mutex group manual release

### DIFF
--- a/rmf_fleet_msgs/CMakeLists.txt
+++ b/rmf_fleet_msgs/CMakeLists.txt
@@ -38,6 +38,7 @@ set(msg_files
   "msg/ChargingAssignment.msg"
   "msg/ChargingAssignments.msg"
   "msg/MutexGroupAssignment.msg"
+  "msg/MutexGroupManualRelease.msg"
   "msg/MutexGroupRequest.msg"
   "msg/MutexGroupStates.msg"
   "msg/BeaconState.msg"

--- a/rmf_fleet_msgs/msg/MutexGroupManualRelease.msg
+++ b/rmf_fleet_msgs/msg/MutexGroupManualRelease.msg
@@ -1,0 +1,11 @@
+# This message allows operators to manually request that a robot release one or
+# more mutex groups that it is currently holding.
+
+# Name of the mutex groups to release
+string[] groups
+
+# The name of the fleet that the robot belongs to
+string fleet
+
+# The name of the robot that needs to release the mutex groups
+string robot

--- a/rmf_fleet_msgs/msg/MutexGroupManualRelease.msg
+++ b/rmf_fleet_msgs/msg/MutexGroupManualRelease.msg
@@ -2,7 +2,7 @@
 # more mutex groups that it is currently holding.
 
 # Name of the mutex groups to release
-string[] groups
+string[] release_mutex_groups
 
 # The name of the fleet that the robot belongs to
 string fleet


### PR DESCRIPTION
This adds a message type that can be used to manually release mutex groups from a robot.