### PR TITLE
Add dry_run field to BidNotice

### DIFF
--- a/rmf_task_msgs/msg/BidNotice.msg
+++ b/rmf_task_msgs/msg/BidNotice.msg
@@ -11,3 +11,7 @@ string task_id
 
 # Duration for which the bidding is open
 builtin_interfaces/Duration time_window
+
+# If true, the Fleet Adapters will still respond with a BidProposal but the
+# task cannot be dispatched to any fleet.
+bool dry_run false


### PR DESCRIPTION
This PR adds a `bool dry_run` field to the `BidNotice` msg. If `true`, the Fleet Adapters will not consider any computed assignments for dispatch. This addition is helpful to infer whether a robot in any fleet is capable of performing a given task without the intention to eventually assign the task to any of the fleets. If avoid the need to send out a cancel request to any assigned task via the dispatcher or publish a `DispatchRequest` to a fleet that does not exist to have all integrated fleets remove the assignment from their queues. 