### PR TITLE
Introduce messages for dynamic events

### DIFF
--- a/rmf_task_msgs/CMakeLists.txt
+++ b/rmf_task_msgs/CMakeLists.txt
@@ -44,6 +44,9 @@ set(msg_files
   "msg/DispatchCommand.msg"
   "msg/DispatchAck.msg"
   "msg/Priority.msg"
+  "msg/LogEntry.msg"
+  "msg/DynamicEventDescription.msg"
+  "msg/DynamicEventStatus.msg"
 )
 
 set(srv_files
@@ -54,9 +57,14 @@ set(srv_files
   "srv/GetDispatchStates.srv"
 )
 
+set(action_files
+  "action/DynamicEvent.action"
+)
+
 rosidl_generate_interfaces(${PROJECT_NAME}
   ${srv_files}
   ${msg_files}
+  ${action_files}
   DEPENDENCIES
     builtin_interfaces
     rmf_dispenser_msgs

--- a/rmf_task_msgs/action/DynamicEvent.action
+++ b/rmf_task_msgs/action/DynamicEvent.action
@@ -1,5 +1,13 @@
 # Action topic:
-# rmf_dynamic_event/command/<fleet_name>/<robot_name>
+# rmf/dynamic_event/command/<fleet_name>/<robot_name>
+
+# The sequence number for this dynamic event. This is unique for each run of a
+# dynamic event within one robot. It must match the dynamic_event_seq field in
+# the DynamicEventDescription which describes the event that is being executed.
+#
+# Each new run of a dynamic event for a robot will increment this value until it
+# reaches integer overflow and goes back to 0.
+uint32 dynamic_event_seq
 
 # What kind of event is this action commanding. Must be one of the following:
 # * EVENT_TYPE_NEXT
@@ -40,6 +48,18 @@ string description
 uint64 id
 
 ---
+
+# An error string that will describe a critical issue that occurred while attempting
+# to begin execution of the action, such as:
+# * a race condition occurs where multiple action requests are submitted simultaneously
+#   for the same robot and both are accepted before either begins
+# * a request is sent while the fleet adapter is shutting down
+# * an error occurs while generating the
+#
+# If this string is empty then no error occurred while beginning execution.
+# If this string is non-empty then the remaining fields in this message will be
+# default-initialized.
+string execution_failure
 
 # The last status of the action before it was finished
 string status

--- a/rmf_task_msgs/action/DynamicEvent.action
+++ b/rmf_task_msgs/action/DynamicEvent.action
@@ -24,7 +24,8 @@ uint32 EVENT_TYPE_UNINITIALIZED=0
 # Indicates that this request describes the next event for the phase to execute.
 uint32 EVENT_TYPE_NEXT=1
 
-# Cancel the currently active event. The id field must match the ID of the
+# Cancel the currently active event. The id field must match the ID of the ID of
+# the currently active event.
 uint32 EVENT_TYPE_CANCEL=2
 
 # Indicates that the dynamic events are finished. After this, no more event commands can

--- a/rmf_task_msgs/action/DynamicEvent.action
+++ b/rmf_task_msgs/action/DynamicEvent.action
@@ -1,0 +1,60 @@
+# Action topic:
+# rmf_dynamic_event/command/<fleet_name>/<robot_name>
+
+# What kind of event is this action commanding. Must be one of the following:
+# * EVENT_TYPE_NEXT
+# * EVENT_TYPE_CANCEL
+# * EVENT_TYPE_FINISHED
+#
+# Any other value will be rejected by the action server.
+uint32 event_type
+
+# Default value for event_type, indicates that the message was default-initialized.
+# This will immediately be rejected by the action server.
+uint32 EVENT_TYPE_UNINITIALIZED=0
+
+# Indicates that this request describes the next event for the phase to execute.
+uint32 EVENT_TYPE_NEXT=1
+
+# Cancel the currently active event. The id field must match the ID of the
+uint32 EVENT_TYPE_CANCEL=2
+
+# Indicates that the dynamic events are finished. After this, no more event commands can
+# be sent until a new Dynamic Event begins.
+uint32 EVENT_TYPE_FINISHED=3
+
+# Used to specify the category of the event when event_type is EVENT_TYPE_NEXT.
+# Otherwise this is unused.
+string category
+
+# Used to describe the event when event_type is EVENT_TYPE_NEXT.
+# Otherwise this is unused.
+string description
+
+# When using EVENT_TYPE_NEXT, this will be the ID for the newly created event.
+#
+# When using EVENT_TYPE_CANCEL, this indicates the ID of the event that is supposed to
+# be cancelled. If it does not match the currently active event ID, then the request will be
+# rejected. If it does match, then the action response will be sent once the event has
+# finished its cancellation.
+uint64 id
+
+---
+
+# The last status of the action before it was finished
+string status
+
+# The ID of the event which has finished
+uint64 id
+
+---
+
+# Current status of the action. This string will match one of the values in the "status" schema:
+# https://github.com/open-rmf/rmf_api_msgs/rmf_api_msgs/schemas/task_state.json
+string status
+
+# The ID of the currently active event.
+uint64 id
+
+# Log messages that have occurred since the last feedback message.
+rmf_task_msgs/LogEntry[] logs

--- a/rmf_task_msgs/action/DynamicEvent.action
+++ b/rmf_task_msgs/action/DynamicEvent.action
@@ -48,6 +48,20 @@ string description
 # finished its cancellation.
 uint64 id
 
+# If this value is greater than 0.0, then the robot will enter a "stubborn" mode
+# after the event is finished where it broadcasts its position to the traffic
+# schedule and behaves like a stubborn negotiator, forcing other robots to wait
+# on it or reroute.
+#
+# The value itself represents the length of time in seconds that the robot will
+# claim it is remaining at its current location. This signal will be refreshed
+# every 1.0s. Values less than 2.0 will be treated as 2.0 with a warning because
+# a stubborn period less than would cause excessive negotiation instability.
+#
+# If you can anticipate how long it will be between this command finishing and
+# the next starting, that time period would be a good value to use here.
+float32 stubborn_period
+
 ---
 
 # An error string that will describe a critical issue that occurred while attempting

--- a/rmf_task_msgs/msg/DynamicEventDescription.msg
+++ b/rmf_task_msgs/msg/DynamicEventDescription.msg
@@ -1,12 +1,19 @@
 # Published to both of the topics:
-# rmf_dynamic_event/begin
-# rmf_dynamic_event/begin/<fleet_name>/<robot_name>
+# rmf/dynamic_event/begin
+# rmf/dynamic_event/begin/<fleet_name>/<robot_name>
 
 # Name of the fleet of the robot beginning the dynamic event.
 string fleet
 
 # Name of the robot beginning the dynamic event.
 string robot
+
+# The sequence number for this dynamic event. This is unique for each run of a
+# dynamic event within one robot.
+#
+# Each new run of a dynamic event for a robot will increment this value until it
+# reaches integer overflow and goes back to 0.
+uint32 dynamic_event_seq
 
 # Full JSON description of the dynamic event, including the estimate field
 # and any custom fields put in by the task request.

--- a/rmf_task_msgs/msg/DynamicEventDescription.msg
+++ b/rmf_task_msgs/msg/DynamicEventDescription.msg
@@ -1,0 +1,16 @@
+# Published to both of the topics:
+# rmf_dynamic_event/begin
+# rmf_dynamic_event/begin/<fleet_name>/<robot_name>
+
+# Name of the fleet of the robot beginning the dynamic event.
+string fleet
+
+# Name of the robot beginning the dynamic event.
+string robot
+
+# Full JSON description of the dynamic event, including the estimate field
+# and any custom fields put in by the task request.
+string description
+
+# What time the dynamic event started.
+builtin_interfaces/Time start_time

--- a/rmf_task_msgs/msg/DynamicEventStatus.msg
+++ b/rmf_task_msgs/msg/DynamicEventStatus.msg
@@ -1,0 +1,30 @@
+# Published to the topic
+# rmf_dynamic_event/status/<fleet_name>/<robot_name>
+
+# Current state of dynamic event execution for the robot associated with the
+# topic that this is being published to.
+uint8 dynamic_state
+
+# There is no dynamic event running right now. Any DynamicEvent action requests
+# will be rejected in this state.
+uint8 DYNAMIC_STATE_INACTIVE = 0
+
+# The dynamic event is waiting for its next command. In this state it would be
+# valid to issue a DynamicEvent action request.
+uint8 DYNAMIC_STATE_WAITING = 1
+
+# The dynamic event is running a command right now. Any DynamicEvent action
+# requests will be rejected in this state.
+uint8 DYNAMIC_STATE_RUNNING = 2
+
+# If the dynamic_state is DYNAMIC_STATE_RUNNING, then this will be the current
+# status of the action. This string will match one of the values in the "status" schema:
+# https://github.com/open-rmf/rmf_api_msgs/rmf_api_msgs/schemas/task_state.json
+string status
+
+# If the dynamic_state is DYNAMIC_STATE_RUNNING, then this will be The ID of the
+# current sub-event within the dynamic event.
+uint64 id
+
+# Timestamp for when this status change occurred.
+builtin_interfaces/Time time

--- a/rmf_task_msgs/msg/DynamicEventStatus.msg
+++ b/rmf_task_msgs/msg/DynamicEventStatus.msg
@@ -1,5 +1,12 @@
 # Published to the topic
-# rmf_dynamic_event/status/<fleet_name>/<robot_name>
+# rmf/dynamic_event/status/<fleet_name>/<robot_name>
+
+# The sequence number for this dynamic event. This is unique for each run of a
+# dynamic event within one robot.
+#
+# Each new run of a dynamic event for a robot will increment this value until it
+# reaches integer overflow and goes back to 0.
+uint32 dynamic_event_seq
 
 # Current state of dynamic event execution for the robot associated with the
 # topic that this is being published to.

--- a/rmf_task_msgs/msg/LogEntry.msg
+++ b/rmf_task_msgs/msg/LogEntry.msg
@@ -1,0 +1,26 @@
+# This is a ROS message definition that matches the log_entry.json schema:
+# https://github.com/open-rmf/rmf_api_msgs/blob/main/rmf_api_msgs/schemas/log_entry.json
+
+# Sequence number for this entry. Each entry has a unique sequence number which
+# monotonically increase, until integer overflow causes a wrap around.
+uint32 seq
+
+# The importance level of the log entry. Must be one of:
+# * TIER_UNINITIALIZED
+# * TIER_INFO
+# * TIER_WARNING
+# * TIER_ERROR
+string tier
+
+string TIER_UNINITIALIZED = "uninitialized"
+string TIER_INFO = "info"
+string TIER_WARNING = "warning"
+string TIER_ERROR = "error"
+
+# The timestamp of this log entry in the number of milliseconds since the beginning
+# of the Unix epoch. We use this instead of builtin_interfaces/Time to perfectly
+# match the log_entry.json schema.
+int64 unix_millis_time
+
+# The text of the log entry
+string text


### PR DESCRIPTION
This is the first PR in implementing [Dynamic Events](https://github.com/open-rmf/rmf/discussions/632).

It differs from the original proposal in a few ways:
* There will no longer be a `rmf_dynamic_event/description/<fleet_name>/<robot_name>` service, instead there will be a `rmf/dynamic_event/status/...` topic with a reliable transient local publisher.
* The `rmf_dynamic_event/description` topic is renamed to `rmf/dynamic_event/begin`, and we also provide a `rmf/dynamic_event/begin/<fleet_name>/<robot_name>` with a reliable transient local publisher and `keep_last(1)` setting.