### PR TITLE
Creation of EmergencySignal.msg

### DIFF
--- a/rmf_fleet_msgs/CMakeLists.txt
+++ b/rmf_fleet_msgs/CMakeLists.txt
@@ -46,6 +46,7 @@ set(msg_files
   "msg/DeliveryAlertAction.msg"
   "msg/DeliveryAlertCategory.msg"
   "msg/DeliveryAlertTier.msg"
+  "msg/EmergencySignal.msg"
 )
 
 set(srv_files

--- a/rmf_fleet_msgs/msg/EmergencySignal.msg
+++ b/rmf_fleet_msgs/msg/EmergencySignal.msg
@@ -1,3 +1,11 @@
+# Specify a list of fleet names who should respond to this change in the
+# emergency signal. If there is one or more entry in this list, then any
+# fleets which are not listed will ignore the message.
+#
+# If this list is completely empty, then all fleets will respond to the
+# emergency signal.
 string[] fleet_names
 
+# True if the relevant fleets should be carrying out their emergency behavior.
+# False if the relevant fleets should carry about their normal business.
 bool is_emergency

--- a/rmf_fleet_msgs/msg/EmergencySignal.msg
+++ b/rmf_fleet_msgs/msg/EmergencySignal.msg
@@ -1,0 +1,3 @@
+string[] fleet_names
+
+bool is_emergency


### PR DESCRIPTION
This PR introduces a new message for emergency signals.

The current implementation uses `std_msgs::msg::bool` for the emergency signal which does not allow any separation between fleets.

This is required is one instance of RMF is implemented for multiple buildings or levels, where users do not want all robots to response when there is a fire alarm.