### PR TITLE
Cleanup geometry_msgs dependencies and remove Pose2D

### DIFF
--- a/rmf_dispenser_msgs/CMakeLists.txt
+++ b/rmf_dispenser_msgs/CMakeLists.txt
@@ -14,7 +14,6 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(builtin_interfaces REQUIRED)
-find_package(geometry_msgs REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 
 set(msg_files
@@ -27,7 +26,7 @@ set(msg_files
 rosidl_generate_interfaces(${PROJECT_NAME}
   ${msg_files}
   ${srv_files}
-  DEPENDENCIES builtin_interfaces geometry_msgs
+  DEPENDENCIES builtin_interfaces
   ADD_LINTER_TESTS
 )
 

--- a/rmf_dispenser_msgs/package.xml
+++ b/rmf_dispenser_msgs/package.xml
@@ -13,11 +13,9 @@
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
   <build_depend>builtin_interfaces</build_depend>
-  <build_depend>geometry_msgs</build_depend>
 
   <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
-  <exec_depend>geometry_msgs</exec_depend>
 
   <test_depend>ament_lint_common</test_depend>
 

--- a/rmf_ingestor_msgs/CMakeLists.txt
+++ b/rmf_ingestor_msgs/CMakeLists.txt
@@ -14,7 +14,6 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(builtin_interfaces REQUIRED)
-find_package(geometry_msgs REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 
 set(msg_files
@@ -29,7 +28,6 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   ${srv_files}
   DEPENDENCIES
     builtin_interfaces
-    geometry_msgs
   ADD_LINTER_TESTS
 )
 

--- a/rmf_ingestor_msgs/package.xml
+++ b/rmf_ingestor_msgs/package.xml
@@ -13,12 +13,10 @@
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
   <build_depend>builtin_interfaces</build_depend>
-  <build_depend>geometry_msgs</build_depend>
   <build_depend>rmf_dispenser_msgs</build_depend>
 
   <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
-  <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>rmf_dispenser_msgs</exec_depend>
 
   <test_depend>ament_lint_common</test_depend>

--- a/rmf_traffic_msgs/CMakeLists.txt
+++ b/rmf_traffic_msgs/CMakeLists.txt
@@ -14,7 +14,6 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(builtin_interfaces REQUIRED)
-find_package(geometry_msgs REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 
 set(msg_files
@@ -63,6 +62,7 @@ set(msg_files
   "msg/NegotiationTreeNode.msg"
   "msg/Participant.msg"
   "msg/Participants.msg"
+  "msg/Pose2D.msg"
   "msg/ScheduleIdentity.msg"
   "msg/ScheduleInconsistency.msg"
   "msg/ScheduleInconsistencyRange.msg"
@@ -91,7 +91,7 @@ set(srv_files
 rosidl_generate_interfaces(${PROJECT_NAME}
   ${msg_files}
   ${srv_files}
-  DEPENDENCIES builtin_interfaces geometry_msgs
+  DEPENDENCIES builtin_interfaces
   ADD_LINTER_TESTS
 )
 

--- a/rmf_traffic_msgs/msg/Pose2D.msg
+++ b/rmf_traffic_msgs/msg/Pose2D.msg
@@ -1,0 +1,3 @@
+float64 x
+float64 y
+float64 theta

--- a/rmf_traffic_msgs/msg/Space.msg
+++ b/rmf_traffic_msgs/msg/Space.msg
@@ -3,4 +3,4 @@
 Shape shape
 
 # The pose of this space
-geometry_msgs/Pose2D pose
+Pose2D pose

--- a/rmf_traffic_msgs/package.xml
+++ b/rmf_traffic_msgs/package.xml
@@ -13,10 +13,8 @@
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
   <build_depend>builtin_interfaces</build_depend>
-  <build_depend>geometry_msgs</build_depend>
 
   <exec_depend>builtin_interfaces</exec_depend>
-  <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
 
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
## Bug fix

### Fixed bug

Fixes #87 

### Fix applied

Make our own `Pose2D` message. I removed the geometry_msgs dependency as well, I also noticed that it was added (probably by accident) to several other packages and cleaned that up

### GenAI Use
We follow [OSRA's policy on GenAI tools](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md)

- [ ] I used a GenAI tool in this PR. 
- [x] I did not use GenAI