### PR TITLE
feat: add RobotCollision.msg to rmf_fleet_msgs

### DIFF
--- a/rmf_fleet_msgs/CMakeLists.txt
+++ b/rmf_fleet_msgs/CMakeLists.txt
@@ -47,6 +47,7 @@ set(msg_files
   "msg/DeliveryAlertCategory.msg"
   "msg/DeliveryAlertTier.msg"
   "msg/EmergencySignal.msg"
+  "msg/RobotCollision.msg"
 )
 
 set(srv_files

--- a/rmf_fleet_msgs/msg/RobotCollision.msg
+++ b/rmf_fleet_msgs/msg/RobotCollision.msg
@@ -1,0 +1,5 @@
+# name of the robot that triggered the collision/emergency stop
+string robot_name
+
+# location of the robot at the time of the collision
+rmf_fleet_msgs/Location location


### PR DESCRIPTION
## New feature implementation

### Implemented feature
This PR adds a new RobotCollision.msg to the rmf_fleet_msgs package. It is added to broadcast collision events and the location of the respective robot when an emergency stop is triggered.

Required for: open-rmf/rmf_simulation#160
Resolves: open-rmf/rmf_simulation#159

### Implementation description
Following the discussion in open-rmf/rmf_simulation#160, this message utilizes the existing rmf_fleet_msgs/Location message structure to accurately use the level_name alongwith the x, y, yaw, and t coordinates.

GenAI Use
We follow [OSRA's policy on GenAI tools](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md)

- [ ] I used a GenAI tool in this PR.
- [x] I did not use GenAI

Generated-by: Used Gemini AI to format the PR description.