### PR TITLE
Add service to add robots dynamically at runtime

### DIFF
--- a/rmf_fleet_msgs/CMakeLists.txt
+++ b/rmf_fleet_msgs/CMakeLists.txt
@@ -52,6 +52,7 @@ set(msg_files
 
 set(srv_files
   "srv/LiftClearance.srv"
+  "srv/AddRobot.srv"
 )
 
 rosidl_generate_interfaces(${PROJECT_NAME}

--- a/rmf_fleet_msgs/srv/AddRobot.srv
+++ b/rmf_fleet_msgs/srv/AddRobot.srv
@@ -1,0 +1,11 @@
+# Name of the robot to be added
+string robot_name
+
+# JSON object with the robot's configuration
+# Supported keys:
+#   compatible_chargers      List (string) name of the robot's charger waypoint
+# e.g. {"compatible_chargers": ["tinyRobot_charger"]}
+string robot_config
+---
+bool success
+string message


### PR DESCRIPTION
## New feature implementation

### Implemented feature

Add a service message for users to add robot dynamically at runtime.

### Implementation description

This PR adds a new `AddRobot.srv` service to `rmf_fleet_msgs`, allowing users to register a robot with a fleet dynamically at runtime.

The service request requires a `robot_name` string and a `robot_config` JSON object defining the robot's configuration. Currently only `compatible_chargers` is required. The response consists of a `success` boolean that reports whether the robot was added successfully and an optional `message` string.

### GenAI Use
We follow [OSRA's policy on GenAI tools](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md)

- [x] I used a GenAI tool in this PR.
- [ ] I did not use GenAI

Generated-by: Claude Opus 4.8
